### PR TITLE
chore(cassandra) upgrade to `3.11`

### DIFF
--- a/docker/docker-compose.yml.sh
+++ b/docker/docker-compose.yml.sh
@@ -189,7 +189,7 @@ EOF
 
   elif [[ $GOJIRA_DATABASE == "cassandra" ]]; then
     cat << EOF
-    image: cassandra:${CASSANDRA:-3.9}
+    image: cassandra:${CASSANDRA:-3.11}
 EOF
 
     if [ "$GOJIRA_NETWORK_MODE" != "host" ]; then


### PR DESCRIPTION
https://hub.docker.com/_/cassandra?tab=tags&page=1&name=3.9

Image `cassandra:3.9` does not support architecture `arm/v8` (Mi chip), perhaps we need to upgrade to `cassandra:3.11` to support it.